### PR TITLE
fix function syntax in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -19,7 +19,7 @@ chsh -s `which fish`
 
 sudo apt-get install -y git terminator xfce4
 
-function windir() {
+windir() {
     echo "/mnt/$1" | sed 's/\\/\//g' | sed 's/\b\(.\):/\L\1/g';
 }
 


### PR DESCRIPTION
functions in bash should use exactly 1 of the function keyword or parens